### PR TITLE
Added bake setting to only bake mapped target bones into the action

### DIFF
--- a/baking.py
+++ b/baking.py
@@ -8,7 +8,10 @@ def draw_panel(ctx, layout):
 	layout.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment and not ctx.setting_disable_drivers
 	row = layout.row()
 	row.prop(ctx, 'setting_bake_step', text='Frame Step')
+	row = layout.row()
 	row.prop(ctx, 'setting_bake_linear', text='Linear Interpolation')
+	row = layout.row()
+	row.prop(ctx, 'setting_bake_selected_bones_only', text='Bake mapped target bones only')
 	layout.operator(BakingBakeOperator.bl_idname, icon='RENDER_ANIMATION')
 	layout.operator(BakingBatchFBXImportOperator.bl_idname, icon='FILE_FOLDER')
 
@@ -51,6 +54,15 @@ def transfer_anim(ctx):
 
 	ctx.target.animation_data.action = target_action
 
+	bpy.ops.object.mode_set(mode='POSE')
+	if ctx.setting_bake_selected_bones_only:
+		for mapping in ctx.mappings:
+			try:
+				target_bone = ctx.target.pose.bones[mapping.target]
+				target_bone.bone.select = True
+			except:
+				pass
+
 	bpy.ops.nla.bake(
 		frame_start=int(min(keyframes)),
 		frame_end=int(max(keyframes)),
@@ -58,7 +70,7 @@ def transfer_anim(ctx):
 		visual_keying=True,
 		use_current_action=True,
 		bake_types={'POSE'},
-		only_selected=False
+		only_selected=ctx.setting_bake_selected_bones_only
 	)
 
 	if ctx.setting_bake_linear:

--- a/context.py
+++ b/context.py
@@ -63,6 +63,7 @@ class Context(bpy.types.PropertyGroup):
 	setting_disable_drivers: bpy.props.BoolProperty(default=False)
 	setting_bake_step: bpy.props.FloatProperty(default=1.0)
 	setting_bake_linear: bpy.props.BoolProperty(default=False)
+	setting_bake_selected_bones_only: bpy.props.BoolProperty(default=False)
 
 	ui_editing_mappings: bpy.props.BoolProperty(default=False)
 	ui_guessing_mappings: bpy.props.BoolProperty(default=False)


### PR DESCRIPTION
This PR adds a new checkbox to the bake panel that allows us to configure the `only_selected` argument for the `bpy.ops.nla.bake` operation and automatically selects all bones in the target armature that we have created a bone mapping for.

This helps us to retarget animation on character rigs that tend to break when we bake keyframes onto all exposed properties. In particular, the Blender studio character rigs that use the CloudRig script tend to turn inside out when keyframes are baked without this change.