### PR TITLE
fix: replace deprecated logger.warn() with logger.warning()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+
+# Blender Animation Retargeting
+
+  
+
+This addon enables the transfer of animations and poses from one armature to another.
+
+  
+  
+
+## Installation
+
+1. Download this repo as .zip
+
+2. In Blender go to Edit > Preferences > Add-ons > Install...
+
+3. Select the downloaded .zip
+
+4. Enable the Add-on, which will appear in the list
+
+  
+  
+
+## How to use
+
+Assuming you have both your target and source armature in the scene, and have them aligned and scaled to match each other.
+
+
+![Both armatures in rest pose next to each other, scaled to be same height](https://mwni.io/opensource/blender-retarget/setup.png)
+
+  
+
+1. Select your target armature and open the add-on panel on the right side of the 3D View (Retarget tab)
+
+2. Now choose the source armature as 'Source' on the panel
+
+3. It should say that there are no bone mappings, yet. Go ahead and click 'Create'.
+
+4. Now map each relevant source bone to the corresponding target. Make sure to not map any bone multiple times, otherwise you'll get undefined behaviour.
+
+5. Next you have to set up the rest pose alignment. Click on "Set up", then change the pose of your target armature in a way, that it optimally fits your source armatures rest pose. When done click 'Apply'.
+
+![pose adjusted to fit source's rest pose](https://mwni.io/opensource/blender-retarget/align.png)
+
+6. The add-on will then automatically create drivers for each bone, and you should be good to go.
+
+  
+
+## Correction Features
+
+### Foot / Hand Positions Correction
+
+If there's significant 'foot-sliding' or odd arm movements, due to anatomical differences between your armatures, you can turn on:
+
+- Correct Feet Position
+
+- Correct Hands Position
+
+  
+
+You will be asked to specify the leg/foot, arm/hand bones respectively.
+
+This will create and IK bone setup for the specified limbs whereas the target positions for the feet/hands are copied over from the source.
+
+Additionally it will spawn a control empty cube, that allows you to transform the target positions as shown in this gif:
+
+  
+
+![demonstration of the ik correction transform cube](https://mwni.io/opensource/blender-retarget/ik_lowres.gif)
+
+  
+
+## Baking
+
+For convenience you can bake the source's animation into an action for your target via the add-on. 
+
+- The option "Linear Interpolation" causes the F-Curves between the keyframes to be linearized instead of the default Blender Bezier interpolation.
+- The option "Bake Mapped Bones Only" ensures that target bones that have no retarget mapping will remain unaffected.
+
+  
+
+![section for baking in the add-on panel](https://mwni.io/opensource/blender-retarget/baking.png)
+
+  
+
+Since the target bones are driven by drivers, you can bake everything youself, if you want. Make sure to check 'Visual Keying' if you do so.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,68 @@
+bl_info = {
+	'name' : 'Animation Retargeting',
+	'author' : 'Mwni',
+	'description' : 'Retarget animations from one armature to another',
+	'version': (2, 3, 1),
+	'blender' : (4, 2, 0),
+	'location' : '3D View > Tools (Right Side) > Retargeting',
+	'category' : 'Animation',
+	'wiki_url': 'https://github.com/Mwni/blender-animation-retargeting',
+    'tracker_url': 'https://github.com/Mwni/blender-animation-retargeting/issues',
+}
+
+import bpy
+from . import context
+from . import main
+from . import mapping
+from . import alignment
+from . import corrections
+from . import baking
+from . import drivers
+from . import ik
+from . import savefile
+from importlib import reload
+
+
+modules = [
+	context,
+	main,
+	mapping,
+	alignment,
+	corrections,
+	baking,
+	drivers,
+	ik,
+	savefile,
+]
+
+
+def register():
+	for i, module in enumerate(modules):
+		modules[i] = reload(module)
+
+	for module in modules:
+		for cls in module.classes:
+			bpy.utils.register_class(cls)
+
+	bpy.types.Object.retargeting_context = bpy.props.PointerProperty(type=modules[0].Context)
+	bpy.app.handlers.load_post.append(post_load)
+
+
+def unregister():
+	for module in modules:
+		for cls in module.classes:
+			bpy.utils.unregister_class(cls)
+
+	del bpy.types.Object.retargeting_context
+
+	if post_load in bpy.app.handlers.load_post:
+		bpy.app.handlers.load_post.remove(post_load)
+
+
+@bpy.app.handlers.persistent
+def post_load(_):
+	from .drivers import update_drivers
+
+	for obj in bpy.data.objects:
+		if obj.type == 'ARMATURE':
+			update_drivers(obj.retargeting_context)

--- a/alignment.py
+++ b/alignment.py
@@ -1,0 +1,171 @@
+import bpy
+from .drivers import clear_drivers, update_drivers
+from .util import matrix_to_list, list_to_matrix
+
+
+def draw_panel(ctx, layout):
+	n = ctx.get_bone_alignments_count()
+
+	if not ctx.ui_editing_alignment:
+		if n == 0 and not ctx.did_setup_empty_alignment:
+			row = layout.row()
+			row.label(text='No rest pose alignment', icon='INFO')
+			row.operator(AlignmentEditOperator.bl_idname, text='Set Up', icon='POSE_HLT')
+		else:
+			row = layout.row()
+			row.label(text='%i Bones with alignment' % n if n > 0 else 'Rest pose is alignment pose', icon='POSE_HLT')
+			row.operator(AlignmentEditOperator.bl_idname, text='Edit', icon='TOOL_SETTINGS')
+			row.operator(AlignmentResetOperator.bl_idname, text='', icon='X')
+	else:
+		layout.label(text='Editing Rest Pose Alignment', icon='POSE_HLT')
+
+		col = layout.column()
+		col.label(text='Align the target\'s pose with the source.', icon='INFO')
+		col.label(text='        The target should mimic the pose of the source as close as possible.')
+
+		row = layout.row()
+		row.operator(AlignmentCancelOperator.bl_idname, text='Cancel', icon='X')
+		row.operator(AlignmentApplyOperator.bl_idname, text='Apply', icon='CHECKMARK')
+
+
+def enter_alignment_mode(ctx):
+	ctx.ui_editing_alignment = True
+	ctx.get_source_armature().pose_position = 'REST'
+	bpy.ops.object.mode_set(mode='POSE')
+
+	clear_drivers(ctx)
+	ctx.target_pose_backup.clear()
+
+	for bone in ctx.target.pose.bones:
+		bp = ctx.target_pose_backup.add()
+		bp.bone = bone.name
+		bp.matrix = matrix_to_list(bone.matrix_basis)
+
+	for bone in ctx.target.pose.bones:
+		for m in ctx.mappings:
+			if m.target == bone.name:
+				bone.matrix_basis = list_to_matrix(m.offset)
+
+	bpy.app.handlers.depsgraph_update_post.append(handle_edit_change)
+
+
+def store_alignments(ctx):
+	for bone in ctx.target.pose.bones:
+		for m in ctx.mappings:
+			if m.target == bone.name:
+				m.rest = matrix_to_list(bone.matrix)
+				m.offset = matrix_to_list(bone.matrix_basis)
+
+
+def leave_alignment_mode(ctx):
+	if handle_edit_change in bpy.app.handlers.depsgraph_update_post:
+		bpy.app.handlers.depsgraph_update_post.remove(handle_edit_change)
+
+	for bone in ctx.target.pose.bones:
+		for bp in ctx.target_pose_backup:
+			if bp.bone == bone.name:
+				bone.matrix_basis = list_to_matrix(bp.matrix)
+				break
+
+	ctx.ui_editing_alignment = False
+	ctx.get_source_armature().pose_position = 'POSE'
+	bpy.ops.object.mode_set(mode='OBJECT')
+	update_drivers(ctx)
+
+
+def handle_edit_change(self, context):
+	if bpy.context.object.mode != 'POSE':
+		leave_alignment_mode(bpy.context.object.retargeting_context)
+
+
+
+class AlignmentEditOperator(bpy.types.Operator):
+	bl_idname = 'alignment.edit'
+	bl_label = 'Change Alignment'
+	bl_description = 'Set the source to target armature rest pose alignment'
+
+	def execute(self, context):
+		enter_alignment_mode(context.object.retargeting_context)
+		return {'FINISHED'}
+
+
+
+class AlignmentApplyOperator(bpy.types.Operator):
+	bl_idname = 'alignment.apply'
+	bl_label = 'Apply Alignment'
+	bl_description = 'Use the current pose as reference rest pose when retargeting'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		store_alignments(ctx)
+
+		if ctx.get_bone_alignments_count() == 0 and not ctx.did_setup_empty_alignment:
+			context.window_manager.popup_menu(
+				title='Alignment pose is rest pose?',
+				icon='QUESTION',
+				draw_func=lambda self, _: (
+					self.layout.label(text='You have not adjusted the alignment pose.'),
+					self.layout.label(text='Does the current rest pose already fit the source?'),
+					self.layout.operator(AlignmentUseEmptyPoseOperator.bl_idname, text='Yes, use this pose', icon='CHECKMARK')
+				)
+			)
+			return {'CANCELLED'}
+
+		leave_alignment_mode(ctx)
+
+		return {'FINISHED'}
+
+
+
+class AlignmentUseEmptyPoseOperator(bpy.types.Operator):
+	bl_idname = 'alignment.use_empty_pose'
+	bl_label = 'Use Empty Alignment Pose'
+	bl_description = 'Use the original rest pose as alignment pose'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.did_setup_empty_alignment = True
+		leave_alignment_mode(ctx)
+		return {'FINISHED'}
+
+
+
+class AlignmentCancelOperator(bpy.types.Operator):
+	bl_idname = 'alignment.cancel'
+	bl_label = 'Cancel Alignment Change'
+	bl_description = 'Discard the current pose and reset to pose before editing'
+
+	def execute(self, context):
+		leave_alignment_mode(context.object.retargeting_context)
+		return {'CANCELLED'}
+
+
+
+class AlignmentResetOperator(bpy.types.Operator):
+	bl_idname = 'alignment.reset'
+	bl_label = 'Reset Rest Pose Alignment'
+	bl_description = 'Discard configured rest pose and start from scratch.'
+	bl_options = {'REGISTER', 'INTERNAL'}
+
+	def invoke(self, context, event):
+		return context.window_manager.invoke_confirm(self, event)
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.did_setup_empty_alignment = False
+
+		for mapping in ctx.mappings:
+			mapping.reset_offset()
+
+		update_drivers(ctx)
+		return {'FINISHED'}
+
+
+
+classes = (
+	AlignmentEditOperator,
+	AlignmentApplyOperator,
+	AlignmentUseEmptyPoseOperator,
+	AlignmentCancelOperator,
+	AlignmentResetOperator
+)

--- a/baking.py
+++ b/baking.py
@@ -1,0 +1,196 @@
+import os
+import bpy
+from bpy_extras.io_utils import ImportHelper
+from .log import info
+
+
+def draw_panel(ctx, layout):
+	layout.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment and not ctx.setting_disable_drivers
+	row = layout.row()
+	row.prop(ctx, 'setting_bake_step', text='Frame Step')
+	row = layout.row()
+	row.prop(ctx, 'setting_bake_linear', text='Linear Interpolation')
+	row = layout.row()
+	row.prop(ctx, 'setting_bake_mapped_bones_only', text='Bake Mapped Bones Only')
+	layout.operator(BakingBakeOperator.bl_idname, icon='RENDER_ANIMATION')
+	layout.operator(BakingBatchFBXImportOperator.bl_idname, icon='FILE_FOLDER')
+
+
+def get_keyframes(obj):
+	frames = []
+	anim = obj.animation_data
+	if anim is not None and anim.action is not None:
+		for fcu in anim.action.fcurves:
+			for keyframe in fcu.keyframe_points:
+				x, y = keyframe.co
+				if x not in frames:
+					frames.append(x)
+
+	return frames
+
+
+def find_action(name):
+	for action in bpy.data.actions:
+		if action.name == name:
+			return action
+
+	return None
+
+
+def transfer_anim(ctx):
+	keyframes = get_keyframes(ctx.source)
+	source_action = ctx.source.animation_data.action
+	target_action_name = ctx.target.name + '|' + source_action.name.replace(ctx.source.name + '|', '')
+	target_action = find_action(target_action_name)
+
+	info('baking %s source animation into action "%s"' % (ctx.source.name, target_action_name))
+
+	if target_action != None:
+		while len(target_action.fcurves) > 0:
+			info('action "%s" already exists: deleting it' % target_action_name)
+			target_action.fcurves.remove(target_action.fcurves[0])
+	else:
+		target_action = bpy.data.actions.new(target_action_name)
+
+	ctx.target.animation_data.action = target_action
+
+	bpy.ops.object.mode_set(mode='POSE')
+
+	for target_bone in ctx.target.pose.bones:
+		if ctx.setting_bake_mapped_bones_only:
+			target_bone.bone.select = True if ctx.get_mapping_for_target(target_bone.name) else False
+		else:
+			target_bone.bone.select = True
+
+	bpy.ops.nla.bake(
+		frame_start=int(min(keyframes)),
+		frame_end=int(max(keyframes)),
+		step=int(ctx.setting_bake_step),
+		visual_keying=True,
+		use_current_action=True,
+		bake_types={'POSE'},
+		only_selected=ctx.setting_bake_mapped_bones_only
+	)
+
+	if ctx.setting_bake_linear:
+		for fc in ctx.target.animation_data.action.fcurves:
+			for kp in fc.keyframe_points:
+				kp.interpolation = 'LINEAR'
+
+	target_action.use_fake_user = True
+
+	info('bake complete')
+
+
+
+class BakingBakeOperator(bpy.types.Operator):
+	bl_idname = 'baking.bake'
+	bl_label = 'Bake into Action'
+	bl_description = 'Inserts animation keyframes transferred from the source based on the configured retargeting'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		transfer_anim(ctx)
+
+		ctx.setting_disable_drivers = True
+		ctx.update_drivers()
+		
+		context.window_manager.popup_menu(
+			title='Bake Complete',
+			icon='INFO',
+			draw_func=lambda self, ctx: (
+				self.layout.label(text='The retargeted animation has been successfully baked into the target armature. Drivers have been disabled so you can review the result animation')
+			)
+		)
+		return {'FINISHED'}
+
+
+
+class BakingBatchFBXImportOperator(bpy.types.Operator, ImportHelper):
+	bl_idname = 'baking.batch_import'
+	bl_label = 'Batch FBX Import & Bake'
+	bl_description = 'Select multiple FBX files having the same source armature, and bake each file\'s animations into an Action on the target armature'
+	
+	directory: bpy.props.StringProperty(subtype='DIR_PATH')
+	files: bpy.props.CollectionProperty(name='File paths', type=bpy.types.OperatorFileListElement)
+	filter_glob: bpy.props.StringProperty(
+		default='*.fbx',
+		options={'HIDDEN'},
+		maxlen=255
+	)
+
+	ignore_leaf_bones: bpy.props.BoolProperty(
+		name='Ignore Leaf Bones',
+		description='Ignore leaf bones during FBX import',
+		default=False,
+	)
+
+	automatic_bone_orientation: bpy.props.BoolProperty(
+		name='Automatic Bone Orientation',
+		description='Automatically orient bones during FBX import',
+		default=False,
+	)
+
+	def draw(self, context):
+		self.layout.prop(self, 'ignore_leaf_bones')
+		self.layout.prop(self, 'automatic_bone_orientation')
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+
+		bpy.context.window_manager.progress_begin(0, len(self.files) * 2)
+		progress = 0
+
+		for file in self.files:
+			bpy.ops.import_scene.fbx(
+				filepath=os.path.join(self.directory, file.name),
+				use_custom_props=True,
+				use_custom_props_enum_as_string=True,
+				ignore_leaf_bones=self.ignore_leaf_bones,
+				automatic_bone_orientation=self.automatic_bone_orientation
+			)
+
+			bpy.context.window_manager.progress_update(progress)
+			progress += 1
+
+			imported_objects = []
+			imported_source = None
+
+			for obj in context.selected_objects:
+				imported_objects.append(obj)
+
+				if obj.type == 'ARMATURE':
+					imported_source = obj
+
+
+			for obj in imported_objects:
+				obj.select_set(False)
+
+			if imported_source != None:
+				imported_action = imported_source.animation_data.action
+				imported_source.scale = ctx.source.scale
+				bpy.context.view_layer.objects.active = ctx.target
+				ctx.target.select_set(True)
+				prev = ctx.source
+				ctx.selected_source = imported_source
+				transfer_anim(ctx)
+				ctx.selected_source = prev
+				imported_source.animation_data.action = None
+				bpy.data.actions.remove(imported_action)
+
+			for obj in imported_objects:
+				bpy.data.objects.remove(obj, do_unlink=True)
+
+			bpy.context.window_manager.progress_update(progress)
+			progress += 1
+
+		bpy.context.window_manager.progress_end()
+
+		return {'FINISHED'}
+
+
+
+classes = (
+	BakingBakeOperator,
+	BakingBatchFBXImportOperator
+)

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,16 @@
+schema_version = "1.0.0"
+
+id = "animation_retargeting"
+name = "Animation Retargeting"
+version = "2.3.1"
+tagline = "Transfer animations and poses from one armature to another"
+maintainer = "Mwni"
+license = ["SPDX:GPL-3.0-or-later"]
+type = "add-on"
+
+website = "https://github.com/Mwni/blender-animation-retargeting"
+tags = ["Animation", "Rigging"]
+blender_version_min = "4.2.0"
+
+[permissions]
+files = "Import/export FBX from/to disk"

--- a/context.py
+++ b/context.py
@@ -1,0 +1,149 @@
+import bpy
+from .mapping import count_incompatible_mappings, warn_incompatible_source_armature
+from .drivers import update_drivers, clear_drivers
+from .ik import update_ik_limbs
+from .log import info
+
+
+class BonePose(bpy.types.PropertyGroup):
+	bone: bpy.props.StringProperty()
+	matrix: bpy.props.FloatVectorProperty(size=16, default=(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1))
+
+
+
+class BoneMapping(bpy.types.PropertyGroup):
+	source: bpy.props.StringProperty()
+	target: bpy.props.StringProperty()
+	rest: bpy.props.FloatVectorProperty(size=16, default=(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1))
+	offset: bpy.props.FloatVectorProperty(size=16, default=(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1))
+
+	def is_valid(self):
+		return (self.source != None 
+				and self.target != None 
+				and len(self.source) > 0 
+				and len(self.target) > 0)
+
+	def reset_offset(self):
+		self.rest = (1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)
+		self.offset = (1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)
+
+
+
+class IKLimb(bpy.types.PropertyGroup):
+	name: bpy.props.StringProperty()
+	enabled: bpy.props.BoolProperty(default=False)
+	target_bone: bpy.props.StringProperty(update=lambda self, ctx: update_ik_limbs(bpy.ctx.object.retargeting_context))
+	origin_bone: bpy.props.StringProperty(update=lambda self, ctx: update_ik_limbs(bpy.ctx.object.retargeting_context))
+	target_empty: bpy.props.PointerProperty(type=bpy.types.Object)
+	target_empty_child: bpy.props.PointerProperty(type=bpy.types.Object)
+	pole_empty: bpy.props.PointerProperty(type=bpy.types.Object)
+	control_holder: bpy.props.PointerProperty(type=bpy.types.Object)
+	control_cube: bpy.props.PointerProperty(type=bpy.types.Object)
+	control_transform: bpy.props.FloatVectorProperty(size=16, default=(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1))
+
+
+
+class Context(bpy.types.PropertyGroup):
+	selected_source: bpy.props.PointerProperty(
+		type=bpy.types.Object,
+		poll=lambda self, obj: obj.type == 'ARMATURE' and obj != bpy.context.object,
+		update=lambda self, ctx: self.handle_source_change()
+	)
+	source: bpy.props.PointerProperty(type=bpy.types.Object)
+	target: bpy.props.PointerProperty(type=bpy.types.Object)
+	target_pose_backup: bpy.props.CollectionProperty(type=BonePose)
+	mappings: bpy.props.CollectionProperty(type=BoneMapping)
+	did_setup_empty_alignment: bpy.props.BoolProperty(default=False)
+	active_mapping: bpy.props.IntProperty()
+	ik_limbs: bpy.props.CollectionProperty(type=IKLimb)
+	is_importing: bpy.props.BoolProperty(default=False)
+
+	setting_correct_feet: bpy.props.BoolProperty(default=False, update=lambda self, ctx: self.handle_ik_change())
+	setting_correct_hands: bpy.props.BoolProperty(default=False, update=lambda self, ctx: self.handle_ik_change())
+	setting_disable_drivers: bpy.props.BoolProperty(default=False)
+	setting_bake_step: bpy.props.FloatProperty(default=1.0)
+	setting_bake_linear: bpy.props.BoolProperty(default=False)
+	setting_bake_mapped_bones_only: bpy.props.BoolProperty(default=False)
+
+	ui_editing_mappings: bpy.props.BoolProperty(default=False)
+	ui_guessing_mappings: bpy.props.BoolProperty(default=False)
+	ui_editing_alignment: bpy.props.BoolProperty(default=False)
+
+
+	def update_drivers(self):
+		update_drivers(self)
+
+	def clear_drivers(self):
+		clear_drivers(self)
+
+
+	def handle_source_change(self, ignore_incompat=False):
+		if self.selected_source == None:
+			return
+
+		if len(self.mappings) > 0 and not ignore_incompat:
+			incompat_n = count_incompatible_mappings(self, self.selected_source)
+
+			if incompat_n > 0:
+				warn_incompatible_source_armature(incompat_n)
+				return
+		
+		info('set source armature to %s' % self.selected_source.name)
+		self.source = self.selected_source
+		self.target = bpy.context.object
+		update_drivers(self)
+
+
+	def handle_ik_change(self):
+		if update_ik_limbs(self):
+			update_drivers(self)
+
+
+	def get_source_armature(self):
+		return self.source.data
+
+
+	def get_target_armature(self):
+		return self.target.data
+	
+
+	def get_bone_alignments_count(self):
+		return sum([
+			1 if any(a!=b for a,b in zip(m.offset, (1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1))) else 0
+			for m in self.mappings
+		])
+	
+
+	def get_mapping_for_target(self, name):
+		for mapping in self.mappings:
+			if mapping.target == name:
+				return mapping
+
+
+	def get_ik_limb_by_name(self, name):
+		for limb in self.ik_limbs:
+			if limb.name == name:
+				return limb
+
+		return None
+	
+
+	def get_guessing_bones(self):
+		return [bone for bone in bpy.context.selected_pose_bones if bone.name in self.target.pose.bones]
+		
+
+	def reset(self):
+		self.mappings.clear()
+		self.ik_limbs.clear()
+		self.setting_correct_feet = False
+		self.setting_correct_hands = False
+		self.did_setup_empty_alignment = True
+
+
+
+classes = (
+	BonePose,
+	BoneMapping,
+	IKLimb,
+	Context,
+)

--- a/corrections.py
+++ b/corrections.py
@@ -1,0 +1,27 @@
+import bpy
+
+
+def draw_panel(ctx, layout):
+	layout.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment
+	layout.prop(ctx, 'setting_correct_feet', text='Correct Feet Position')
+	if ctx.setting_correct_feet:
+		row = layout.box().row()
+		draw_limb_section(row.column(), 'Left Foot', 'Left Thigh', ctx, ctx.get_ik_limb_by_name('left-foot'))
+		draw_limb_section(row.column(), 'Right Foot', 'Right Thigh', ctx, ctx.get_ik_limb_by_name('right-foot'))
+
+	layout.prop(ctx, 'setting_correct_hands', text='Correct Hands Position')
+	if ctx.setting_correct_hands:
+		row = layout.box().row()
+		draw_limb_section(row.column(), 'Left Hand', 'Left Upper Arm', ctx, ctx.get_ik_limb_by_name('left-hand'))
+		draw_limb_section(row.column(), 'Right Hand', 'Right Upper Arm', ctx, ctx.get_ik_limb_by_name('right-hand'))
+	
+
+def draw_limb_section(layout, target_label, origin_label, ctx, prop):
+	layout.label(text=origin_label)
+	layout.prop_search(prop, 'origin_bone', ctx.get_target_armature(), 'bones', text='', icon='BONE_DATA')
+	layout.label(text=target_label)
+	layout.prop_search(prop, 'target_bone', ctx.get_target_armature(), 'bones', text='', icon='BONE_DATA')
+
+
+
+classes = []

--- a/drivers.py
+++ b/drivers.py
@@ -1,0 +1,300 @@
+import bpy
+from mathutils import Matrix, Vector, Quaternion
+from .mapping import get_intermediate_bones
+from .ik import update_ik_controls, clear_ik_controls
+from .util import rot_mat, loc_mat, list_to_matrix, extract_loc_axis_from_mat, extract_rot_axis_from_mat
+from .log import info
+
+
+def draw_panel(ctx, layout):
+	layout.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment
+	
+	if ctx.setting_disable_drivers:
+		split = layout.split(factor=0.63)
+		split.label(text='Bone Drivers disabled', icon='ERROR')
+		split.operator(DriversEnableOperator.bl_idname, text='Enable', icon='CHECKMARK')
+	else:
+		split = layout.split(factor=0.38)
+		status = split.column()
+		actions = split.row()
+
+		status.label(text='%i Bone Drivers' % len(ctx.mappings), icon='DRIVER')
+		actions.operator(DriversRebuildOperator.bl_idname, text='Rebuild', icon='FILE_REFRESH')
+		actions.operator(DriversDisableOperator.bl_idname, text='Disable', icon='X')
+
+		ik_drivers_n = sum([1 if limb.enabled else 0 for limb in ctx.ik_limbs])
+
+		if ik_drivers_n > 0:
+			status.label(text='%i IK Drivers' % ik_drivers_n, icon='CON_KINEMATIC')
+			actions.scale_y = 2
+
+
+
+def update_drivers(ctx):
+	if ctx.is_importing:
+		return
+
+	if not ctx.setting_disable_drivers and (ctx.get_bone_alignments_count() > 0 or ctx.did_setup_empty_alignment):
+		update_ik_controls(ctx)
+		clear_drivers(ctx)
+		build_drivers(ctx)
+	else:
+		clear_ik_controls(ctx)
+		clear_drivers(ctx)
+
+
+def clear_drivers(ctx):
+	for mapping in ctx.mappings:
+		dest_pose = ctx.target.pose.bones[mapping.target]
+		dest_pose.driver_remove('location')
+		dest_pose.driver_remove('rotation_euler')
+		dest_pose.matrix_basis = Matrix()
+
+	for limb in ctx.ik_limbs:
+		if limb.target_empty != None:
+			limb.target_empty.driver_remove('location')
+			limb.target_empty.driver_remove('rotation_euler')
+
+	info('cleared drivers')
+
+
+def create_vars(loc_driver, rot_driver, t, s_source, mapping_source, space, offset=0):
+	src_vars = []
+
+	for tt in t:
+		for ta in (('W', 'X', 'Y', 'Z') if tt == 'ROT' else ('X', 'Y', 'Z')):
+			for driver in (loc_driver, rot_driver):
+				var = driver.variables.new()
+				var.name = chr(65 + len(src_vars) + offset)
+				var.type = 'TRANSFORMS'
+				var.targets[0].id = s_source
+				var.targets[0].bone_target = mapping_source
+				var.targets[0].rotation_mode = 'QUATERNION'
+				var.targets[0].transform_space = space
+				var.targets[0].transform_type = tt + '_' + ta
+
+			src_vars.append(var.name)
+
+	return src_vars
+
+
+def build_drivers(ctx):
+	bpy.app.driver_namespace['retarget_bone_rot'] = drive_bone_rot
+	bpy.app.driver_namespace['retarget_bone_loc'] = drive_bone_loc
+	bpy.app.driver_namespace['retarget_ik_rot'] = drive_ik_target_rot
+	bpy.app.driver_namespace['retarget_ik_loc'] = drive_ik_target_loc
+
+	for mapping in ctx.mappings:
+		dest_pose = ctx.target.pose.bones[mapping.target]
+		intermediate_bones = get_intermediate_bones(ctx, mapping)
+
+		dest_pose.rotation_mode = 'XYZ'
+
+		loc_drivers = dest_pose.driver_add('location')
+		rot_drivers = dest_pose.driver_add('rotation_euler')
+
+
+		for axis, lfc, rfc in zip(('x','y','z'), loc_drivers, rot_drivers):
+			loc_driver = lfc.driver
+			rot_driver = rfc.driver
+
+			src_vars = create_vars(loc_driver, rot_driver, ('LOC', 'ROT'), ctx.source, mapping.source, 'LOCAL_SPACE')
+
+			loc_driver.expression = "retarget_bone_loc('%s','%s','%s',[%s],[%s])" % (
+				ctx.target.name, 
+				mapping.target, 
+				axis, 
+				','.join(src_vars),
+				','.join(['"%s"' % bone for bone in intermediate_bones])
+			)
+			rot_driver.expression = "retarget_bone_rot('%s','%s','%s',[%s],[%s])" % (
+				ctx.target.name, 
+				mapping.target, 
+				axis, 
+				','.join(src_vars),
+				','.join(['"%s"' % bone for bone in intermediate_bones])
+			)
+
+	
+	for i, limb in enumerate(ctx.ik_limbs):
+		if not limb.enabled:
+			continue
+
+		mapping = ctx.get_mapping_for_target(limb.target_bone)
+
+		loc_drivers = limb.target_empty.driver_add('location')
+		rot_drivers = limb.target_empty.driver_add('rotation_euler')
+
+		for axis, lfc, rfc in zip(('x','y','z'), loc_drivers, rot_drivers):
+			loc_driver = lfc.driver
+			rot_driver = rfc.driver
+
+			src_vars = create_vars(loc_driver, rot_driver, ('LOC', 'ROT'), ctx.source, mapping.source, 'WORLD_SPACE')
+			ctl_vars = create_vars(loc_driver, rot_driver, ('LOC', 'ROT', 'SCALE'), limb.control_cube, '', 'LOCAL_SPACE', offset=len(src_vars))
+
+			loc_driver.expression = "retarget_ik_loc('%s',%i,'%s',[%s])" % (ctx.target.name, i, axis, ','.join(src_vars + ctl_vars))
+			rot_driver.expression = "retarget_ik_rot('%s',%i,'%s',[%s])" % (ctx.target.name, i, axis, ','.join(src_vars + ctl_vars))
+
+	info('built drivers')
+
+
+
+class DriversEnableOperator(bpy.types.Operator):
+	bl_idname = 'drivers.enable'
+	bl_label = 'Enable Drivers'
+	bl_description = 'Build and apply all bone drivers according to the current setup'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.setting_disable_drivers = False
+		update_drivers(ctx)
+		return {'FINISHED'}
+
+
+class DriversRebuildOperator(bpy.types.Operator):
+	bl_idname = 'drivers.rebuild'
+	bl_label = 'Rebuild Drivers'
+	bl_description = 'Rebuild and apply all bone drivers. This is useful when there was a change that the addon missed'
+
+	def execute(self, context):
+		update_drivers(context.object.retargeting_context)
+		return {'FINISHED'}
+	
+
+class DriversDisableOperator(bpy.types.Operator):
+	bl_idname = 'drivers.disable'
+	bl_label = 'Disable Drivers'
+	bl_description = 'Clear all existing bone drivers and IK controls'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.setting_disable_drivers = True
+		update_drivers(ctx)
+		return {'FINISHED'}
+
+
+
+### DRIVER EXPRESSIONS 
+
+
+def drive_bone_mat(armature_name, bone_name, src_vars, intermediate_bones):
+	armature = bpy.data.objects[armature_name]
+	ctx = armature.retargeting_context
+	mapping = ctx.get_mapping_for_target(bone_name)
+	bone_loc = Vector(src_vars[0:3])
+	bone_rot = Quaternion(src_vars[3:])
+
+	if len(intermediate_bones) > 0:
+		src_bone = ctx.source.pose.bones[mapping.source]
+		head_bone = ctx.source.pose.bones[intermediate_bones[0]]
+		tail_bone = ctx.source.pose.bones[intermediate_bones[-1]]
+
+		if tail_bone.parent:
+			base_bone = tail_bone.parent
+			base_rest = base_bone.bone.matrix_local
+			base_pose = base_bone.matrix
+		else:
+			base_rest = Matrix()
+			base_pose = Matrix()
+
+		head_rest = head_bone.bone.matrix_local
+		head_pose = head_bone.matrix
+
+		based_pose = base_pose.inverted() @ head_pose
+		based_rest = base_rest.inverted() @ head_rest
+		based_delta = based_rest.inverted() @ based_pose
+
+		src_rest = src_bone.bone.matrix.to_4x4()
+		mapped_delta = src_rest.inverted() @ based_delta @ src_rest
+
+		bone_rot @= mapped_delta.to_quaternion()
+		bone_loc += mapped_delta.to_translation()
+
+	rest_mat = list_to_matrix(mapping.rest)
+	offset_mat = list_to_matrix(mapping.offset)
+
+	src_data = ctx.source.data.bones[mapping.source]
+	src_ref_mat = rot_mat(ctx.source.matrix_world) @ rot_mat(src_data.matrix_local)
+	dest_ref_mat = rot_mat(ctx.target.matrix_world) @ rot_mat(rest_mat)
+	diff_mat = src_ref_mat.inverted() @ dest_ref_mat
+
+	src_scale = ctx.source.matrix_world.to_scale()
+	src_scale_mat = Matrix.Identity(4)
+	src_scale_mat[0][0] = src_scale.x
+	src_scale_mat[1][1] = src_scale.y
+	src_scale_mat[2][2] = src_scale.z
+
+	dest_scale = ctx.target.matrix_world.to_scale()
+	dest_scale_mat = Matrix.Identity(4)
+	dest_scale_mat[0][0] = dest_scale.x
+	dest_scale_mat[1][1] = dest_scale.y
+	dest_scale_mat[2][2] = dest_scale.z
+
+	mat = Matrix.Translation(bone_loc) @ bone_rot.to_matrix().to_4x4()
+	mat = dest_scale_mat.inverted() @ src_scale_mat @ mat
+	mat = diff_mat.inverted() @ mat @ diff_mat
+	mat = offset_mat @ mat
+	mat = mat
+
+	return mat
+
+
+def drive_bone_rot(armature_name, bone_name, axis, src_vars, intermediate_bones):
+	mat = drive_bone_mat(armature_name, bone_name, src_vars, intermediate_bones)
+	return extract_rot_axis_from_mat(mat, axis)
+
+
+def drive_bone_loc(armature_name, bone_name, axis, src_vars, intermediate_bones):
+	mat = drive_bone_mat(armature_name, bone_name, src_vars, intermediate_bones)
+	return extract_loc_axis_from_mat(mat, axis)
+
+
+def drive_ik_target_mat(armature_name, index, src_vars):
+	mat = Matrix.Translation(Vector(src_vars[0:3]))
+	quat = Quaternion(src_vars[3:7])
+	mat = mat @ quat.to_matrix().to_4x4()
+
+	src_vars = src_vars[7:]
+
+	ctl_mat = Matrix.Translation(Vector(src_vars[0:3]))
+	ctl_quat = Quaternion(src_vars[3:7])
+	ctl_mat = ctl_mat @ ctl_quat.to_matrix().to_4x4()
+	ctl_scale = Matrix.Scale(src_vars[7], 4, (1, 0, 0))
+	ctl_scale @= Matrix.Scale(src_vars[8], 4, (0, 1, 0))
+	ctl_scale @= Matrix.Scale(src_vars[9], 4, (0, 0, 1))
+	ctl_mat = ctl_mat @ ctl_scale
+
+	obj = bpy.data.objects[armature_name]
+	ctx = obj.retargeting_context
+	limb = ctx.ik_limbs[index]
+	mapping = ctx.get_mapping_for_target(limb.target_bone)
+	src_data = ctx.source.data.bones[mapping.source]
+
+	src_world_mat = loc_mat(ctx.source.matrix_world).inverted() @ ctx.source.matrix_world
+	src_ref_mat = ctx.source.matrix_world @ loc_mat(src_data.matrix_local)
+	src_rot_mat = rot_mat(ctx.source.matrix_world) @ rot_mat(src_data.matrix_local)
+	dest_rest_mat = list_to_matrix(mapping.rest)
+	dest_rot_mat = rot_mat(ctx.target.matrix_world) @ rot_mat(dest_rest_mat)
+	diff_rot_mat = src_rot_mat.inverted() @ dest_rot_mat
+
+	mat = src_world_mat @ src_ref_mat.inverted() @ loc_mat(dest_rest_mat) @ ctl_mat @ mat @ diff_rot_mat
+
+	return mat
+
+
+def drive_ik_target_rot(armature_name, index, axis, src_vars):
+	mat = drive_ik_target_mat(armature_name, index, src_vars)
+	return extract_rot_axis_from_mat(mat, axis)
+
+
+def drive_ik_target_loc(armature_name, index, axis, src_vars):
+	mat = drive_ik_target_mat(armature_name, index, src_vars)
+	return extract_loc_axis_from_mat(mat, axis)
+
+
+
+classes = (
+	DriversEnableOperator,
+	DriversRebuildOperator,
+	DriversDisableOperator
+)

--- a/ik.py
+++ b/ik.py
@@ -1,0 +1,175 @@
+
+import bpy
+from mathutils import Vector
+from .util import loc_mat, list_to_matrix, matrix_to_list
+from .log import info
+
+
+def update_ik_limbs(ctx):
+	if ctx.is_importing:
+		return
+
+	needs_rebuild = False
+
+	for active, name in ((ctx.setting_correct_feet, 'left-foot'), (ctx.setting_correct_feet, 'right-foot'), 
+						(ctx.setting_correct_hands, 'left-hand'), (ctx.setting_correct_hands, 'right-hand')):
+		limb = ctx.get_ik_limb_by_name(name)
+
+		if limb == None:
+			limb = create_ik_limb(ctx, name)
+
+		was_enabled = limb.enabled
+
+		limb.enabled = (
+			active
+			and limb.target_bone != None and limb.target_bone != ''
+			and limb.origin_bone != None and limb.origin_bone != ''
+		)
+
+		if was_enabled != limb.enabled:
+			needs_rebuild = True
+
+	return needs_rebuild
+
+
+def create_ik_limb(ctx, name):
+	limb = ctx.ik_limbs.add()
+	limb.name = name
+	limb.enabled = False
+
+	return limb
+
+
+def update_ik_controls(ctx):
+	clear_ik_controls(ctx)
+	build_ik_controls(ctx)
+
+
+def clear_ik_controls(ctx):
+	for limb in ctx.ik_limbs:
+
+		if limb.target_bone in ctx.target.pose.bones:
+			target_bone = ctx.target.pose.bones[limb.target_bone]
+
+			for con in target_bone.constraints:
+				if con.name == 'Retarget IK':
+					target_bone.constraints.remove(con)
+					break
+
+		if limb.target_empty_child != None:
+			bpy.data.objects.remove(limb.target_empty_child, do_unlink=True)
+			limb.target_empty_child = None
+
+		if limb.target_empty != None:
+			bpy.data.objects.remove(limb.target_empty, do_unlink=True)
+			limb.target_empty = None
+
+		#if limb.pole_empty != None:
+		#	bpy.data.objects.remove(limb.pole_empty, do_unlink=True)
+		#	limb.pole_empty = None
+
+		if limb.control_cube != None:
+			limb.control_transform = matrix_to_list(limb.control_cube.matrix_local)
+			bpy.data.objects.remove(limb.control_cube, do_unlink=True)
+			limb.control_cube = None
+
+		if limb.control_holder != None:
+			bpy.data.objects.remove(limb.control_holder, do_unlink=True)
+			limb.control_holder = None
+
+	info('cleared IK controls')
+
+
+def build_ik_controls(ctx):
+	aux_collection = next((c for c in bpy.data.collections if c.name == 'Retargeting Auxiliary'), None)
+	ctl_collection = next((c for c in bpy.data.collections if c.name == 'Retargeting Control'), None)
+
+	if aux_collection == None:
+		aux_collection = bpy.data.collections.new('Retargeting Auxiliary')
+		#aux_collection.hide_viewport = True
+		bpy.context.scene.collection.children.link(aux_collection)
+
+	if ctl_collection == None:
+		ctl_collection = bpy.data.collections.new('Retargeting Control')
+		bpy.context.scene.collection.children.link(ctl_collection)
+
+	h = ctx.target.dimensions.z
+
+	for limb in ctx.ik_limbs:
+		if not limb.enabled:
+			continue
+
+		target_data_bone = ctx.target.data.bones[limb.target_bone]
+		target_bone = ctx.target.pose.bones[limb.target_bone]
+
+		te = bpy.data.objects.new(limb.target_bone + '-target', None)
+		tec = bpy.data.objects.new(limb.target_bone + '-target-child', None)
+		te.empty_display_size = h * 0.1
+		te.empty_display_type = 'PLAIN_AXES'
+		tec.empty_display_size = 0
+		tec.empty_display_type = 'PLAIN_AXES'
+		aux_collection.objects.link(te)
+		aux_collection.objects.link(tec)
+		te.parent = ctx.target
+		tec.parent = te
+
+		head = Vector(target_data_bone.head_local)
+		tail = Vector(target_data_bone.tail_local)
+		offset = head - tail
+
+		tec.location.x = 0
+		tec.location.y = target_data_bone.length
+		tec.location.z = 0
+
+		#pe = bpy.data.objects.new(limb.target_bone + '-pole', None)
+		#pe.empty_display_size = h * 0.1
+		#pe.empty_display_type = 'PLAIN_AXES'
+		#aux_collection.objects.link(pe)
+		#pe.parent = s.target
+
+		ch = bpy.data.objects.new(limb.target_bone + '-transform-holder', None)
+		ch.empty_display_size = 0
+		ctl_collection.objects.link(ch)
+		ch.parent = ctx.target
+		ch.matrix_local = loc_mat(target_data_bone.matrix_local)
+
+		cc = bpy.data.objects.new(limb.target_bone + '-transform', None)
+		cc.empty_display_size = h * 0.1
+		cc.empty_display_type = 'CUBE'
+		ctl_collection.objects.link(cc)
+		cc.parent = ch
+		cc.matrix_local = list_to_matrix(limb.control_transform)
+		#ce.location.x, ce.location.y, ce.location.z = target_data_bone.matrix_local.translation
+
+		con = target_bone.constraints.new('IK')
+		con.name = 'Retarget IK'
+		con.target = tec
+		#con.pole_target = pe
+		con.use_rotation = True
+
+		tb = target_bone.parent
+		tbn = 0
+
+		while tb != None:
+			tbn += 1
+
+			tb.lock_ik_x, tb.lock_ik_y, tb.lock_ik_z = tb.lock_rotation
+
+			if tb.name == limb.origin_bone:
+				break
+
+			tb = tb.parent
+
+		con.chain_count = tbn + 1
+
+		limb.target_empty = te
+		limb.target_empty_child = tec
+		#limb.pole_empty = pe
+		limb.control_holder = ch
+		limb.control_cube = cc
+
+	info('built IK controls')
+
+
+
+classes = []

--- a/log.py
+++ b/log.py
@@ -1,0 +1,11 @@
+from logging import basicConfig, getLogger, INFO
+
+basicConfig(level=INFO, format='[%(name)s] %(message)s')
+
+logger = getLogger('anim-retarget-addon')
+
+def info(text):
+    logger.info(text)
+    
+def warn(text):
+    logger.warning(text)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,66 @@
+import bpy
+from . import savefile
+from . import mapping
+from . import alignment
+from . import corrections
+from . import drivers
+from . import baking
+
+
+class MainPanel(bpy.types.Panel):
+	bl_idname = 'RT_PT_Main'
+	bl_label = 'Animation Retargeting'
+	bl_category = 'Retargeting'
+	bl_space_type = 'VIEW_3D'
+	bl_region_type = 'UI'
+
+	def draw(self, context):
+		layout = self.layout
+
+		if context.object != None and context.object.type == 'ARMATURE':
+			ctx = context.object.retargeting_context
+
+			split = layout.row().split(factor=0.244)
+			split.column().label(text='Target:')
+			split.column().label(text=context.object.name, icon='ARMATURE_DATA')
+
+			row = layout.row()
+			row.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment
+			row.prop(ctx, 'selected_source', text='Source', icon='ARMATURE_DATA')
+
+			layout.separator()
+
+			if ctx.source == None:
+				layout.label(text='Choose a source armature to continue', icon='INFO')
+			else:
+				savefile.draw_panel(ctx, layout.box())
+				layout.separator()
+				layout.label(text='Bone Mappings')
+				mapping.draw_panel(ctx, layout.box())
+
+				if not ctx.ui_editing_mappings and len(ctx.mappings) > 0:
+					layout.separator()
+					layout.label(text='Rest Alignment')
+					alignment.draw_panel(ctx, layout.box())
+
+					if ctx.get_bone_alignments_count() > 0 or ctx.did_setup_empty_alignment:
+						layout.separator()
+						layout.label(text='Corrections')
+						corrections.draw_panel(ctx, layout.box())
+
+						layout.separator()
+						layout.label(text='Drivers')
+						drivers.draw_panel(ctx, layout.box())
+
+						layout.separator()
+						layout.label(text='Baking')
+						baking.draw_panel(ctx, layout.box())
+						
+		else:
+			layout.label(text='Select target armature', icon='ERROR')
+
+
+
+classes = (
+	MainPanel,
+)

--- a/mapping.py
+++ b/mapping.py
@@ -1,0 +1,382 @@
+import bpy
+from difflib import SequenceMatcher
+
+
+bone_synonyms = (
+	('clavicle', 'shoulder', 'collar'),
+	('upperarm', 'uparm', 'shoulder'),
+	('lowerarm', 'loarm', 'forearm'),
+	('pinky', 'little'),
+	('pelvis', 'spine', 'abdomen'),
+	('upperleg', 'thigh'),
+	('lowerleg', 'shin', 'calf'),
+	('foot', 'ankle'),
+	('ball', 'toe'),
+)
+
+
+def draw_panel(ctx, layout):
+	n = len(ctx.mappings)
+
+	if not ctx.ui_editing_mappings:
+		layout.enabled = not ctx.ui_editing_alignment
+
+		if n == 0:
+			row = layout.row()
+			row.label(text='No Bone Mappings', icon='INFO')
+			row.operator(MappingsEditOperator.bl_idname, text='Create', icon='PRESET_NEW')
+		else:
+			row = layout.row()
+			row.label(text='%i Bone Pairs' % n, icon='GROUP_BONE')
+			row.operator(MappingsEditOperator.bl_idname, text='Edit', icon='TOOL_SETTINGS')
+			row.operator(MappingsClearOperator.bl_idname, text='', icon='X')
+	elif ctx.ui_guessing_mappings:
+		layout.label(text='Guessing Bone Pairs', icon='LIGHT')
+
+		bones_n = len(ctx.get_guessing_bones())
+
+		if bones_n == 0:
+			layout.label(text='Select all bones that should be guessed', icon='INFO')
+		else:
+			layout.label(text='%i Bones selected for guess' % bones_n, icon='BONE_DATA')
+		
+		row = layout.row()
+		row.operator(MappingsGuessCancelOperator.bl_idname, text='Cancel', icon='X')
+		row.operator(MappingsGuessApplyOperator.bl_idname, text='Guess', icon='SHADERFX')
+	else:
+		row = layout.split(factor=0.63)
+		row.label(text='Editing %i Bone Pairs' % n, icon='GROUP_BONE')
+		row.operator(MappingsGuessOperator.bl_idname, text='Guess', icon='LIGHT')
+
+		row = layout.row()
+		row.template_list('RT_UL_mappings', '', ctx, 'mappings', ctx, 'active_mapping')
+
+		col = row.column(align=True)
+		col.operator(MappingsListActionOperator.bl_idname, icon='ADD', text='').action = 'ADD'
+		col.operator(MappingsListActionOperator.bl_idname, icon='REMOVE', text='').action = 'REMOVE'
+
+		layout.operator(MappingsApplyOperator.bl_idname, text='Done', icon='CHECKMARK')
+
+
+
+def enter_mapping_mode(ctx):
+	ctx.ui_editing_mappings = True
+	ctx.get_source_armature().pose_position = 'REST'
+	ctx.get_target_armature().pose_position = 'REST'
+	ctx.source.select_set(True)
+
+	bpy.ops.object.mode_set(mode='POSE')
+	bpy.app.handlers.depsgraph_update_post.append(handle_edit_change)
+
+
+def guess_mappings(ctx):
+	source_bones = [bone.name for bone in ctx.source.pose.bones]
+	target_bones = [bone.name for bone in ctx.get_guessing_bones()]
+	source_sides = guess_group_by_side(source_bones)
+	target_sides = guess_group_by_side(target_bones)
+
+	mappings = []
+
+	for side in ('l', 'r', 'x'):
+		mappings += guess_map_by_name(source_sides[side], target_sides[side])
+
+	for sbone, tbone in mappings:
+		if sbone in [m.source for m in ctx.mappings]:
+			continue
+
+		if tbone in [m.target for m in ctx.mappings]:
+			continue
+
+		mapping = ctx.mappings.add()
+		mapping.source = sbone
+		mapping.target = tbone
+
+		ctx.active_mapping = len(ctx.mappings) - 1
+
+	ctx.ui_guessing_mappings = False
+	ctx.source.select_set(True)
+
+
+def guess_map_by_name(source_bones, target_bones):
+	mappings_source = []
+	mappings_target = []
+	matches = []
+
+	for tbone in target_bones:
+		for sbone in source_bones:
+			sbone_lower, tbone_lower = guess_apply_synonym(sbone.lower(), tbone.lower())
+			matcher = SequenceMatcher(None, sbone_lower, tbone_lower)
+
+			if matcher.find_longest_match().size <= 1:
+				continue
+
+			matches.append((sbone, tbone, matcher.ratio()))
+
+	matches = sorted(matches, key=lambda m: m[2], reverse=True)
+
+	for sbone, tbone, _ in matches:
+		if sbone in mappings_source or tbone in mappings_target:
+			continue
+
+		mappings_source.append(sbone)
+		mappings_target.append(tbone)
+
+	return list(zip(mappings_source, mappings_target))
+
+
+def guess_apply_synonym(source_bone, target_bone):
+	for synonyms in bone_synonyms:
+		for key in synonyms:
+			if key not in source_bone:
+				continue
+			
+			other = [s for s in synonyms if s != key]
+
+			for o in other:
+				if o in target_bone:
+					return source_bone, target_bone.replace(o, key)
+				
+	return source_bone, target_bone
+
+
+def guess_group_by_side(bones):
+	groups = {
+		'l': [],
+		'r': [],
+		'x': []
+	}
+
+	for bone in bones:
+		if bone in groups['l'] or bone in groups['r']:
+			continue
+
+		found_match = False
+
+		if 'right' in bone.lower():
+			for partner in bones:
+				if partner == bone:
+					continue
+
+				if bone.lower() == partner.lower().replace('left', 'right'):
+					groups['r'].append(bone)
+					groups['l'].append(partner)
+					found_match = True
+					break
+		else:
+			potential_partners = [b for b in bones if b != bone and len(b) == len(bone)]
+			
+			for i, char in enumerate(bone):
+				if char.lower() != 'r':
+					continue
+
+				for partner in potential_partners:
+					if bone == partner[0:i] + char + partner[i+1:]:
+						groups['r'].append(bone)
+						groups['l'].append(partner)
+						found_match = True
+						break
+
+				if found_match:
+					break
+
+		if not found_match:
+			groups['x'].append(bone)
+
+	return groups
+
+
+def leave_mapping_mode(ctx):
+	if handle_edit_change in bpy.app.handlers.depsgraph_update_post:
+		bpy.app.handlers.depsgraph_update_post.remove(handle_edit_change)
+
+	ctx.ui_editing_mappings = False
+	ctx.get_source_armature().pose_position = 'POSE'
+	ctx.get_target_armature().pose_position = 'POSE'
+	ctx.source.select_set(False)
+
+	bpy.ops.object.mode_set(mode='OBJECT')
+	
+
+def handle_edit_change(self, context):
+	if bpy.context.object.mode != 'POSE':
+		leave_mapping_mode(bpy.context.object.retargeting_context)
+
+
+def get_intermediate_bones(ctx, mapping):
+	bone = ctx.source.pose.bones[mapping.source]
+	intermediate_bones = []
+
+	while bone.parent and not any(m.source == bone.parent.name for m in ctx.mappings):
+		intermediate_bones.append(bone.parent.name)
+		bone = bone.parent
+
+	return intermediate_bones
+
+
+def count_incompatible_mappings(ctx, target):
+	count = 0
+
+	for mapping in ctx.mappings:
+		if all(bone.name != mapping.source for bone in target.data.bones):
+			count += 1
+
+	return count
+
+
+def warn_incompatible_source_armature(incompat_n):
+	bpy.context.window_manager.popup_menu(
+		title='Incompatible armature', 
+		icon='ERROR',
+		draw_func=lambda self, _: (
+			self.layout.label(text='Corresponding bones for %i mapping(s) not found.' % incompat_n) +
+			self.layout.operator('retarget.use_invalid_source_anyway')
+		)
+	)
+
+
+
+class RT_UL_mappings(bpy.types.UIList):
+	def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index, flt_flag):
+		ctx = context.object.retargeting_context
+		layout.alert = not item.is_valid()
+		layout.prop_search(item, 'source', ctx.get_source_armature(), 'bones', text='', icon='BONE_DATA')
+		layout.label(icon='FORWARD')
+		layout.prop_search(item, 'target', ctx.get_target_armature(), 'bones', text='', icon='BONE_DATA')
+
+	def draw_filter(self, context, layout):
+		pass
+
+	def filter_items(self, context, data, propname):
+		flt_flags = []
+		flt_neworder = []
+
+		return flt_flags, flt_neworder
+
+
+
+class MappingsEditOperator(bpy.types.Operator):
+	bl_idname = 'mappings.edit'
+	bl_label = 'Create'
+	bl_description = 'Map individual bones from the source armature to the target armature'
+
+	def execute(self, context):
+		enter_mapping_mode(context.object.retargeting_context)
+		return {'FINISHED'}
+
+
+
+class MappingsApplyOperator(bpy.types.Operator):
+	bl_idname = 'mappings.apply'
+	bl_label = 'Apply'
+	bl_description = 'Save and use the created bone mappings'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+
+		if any(not mapping.is_valid() for mapping in ctx.mappings):
+			bpy.context.window_manager.popup_menu(
+				title='Invalid Mappings', 
+				icon='ERROR',
+				draw_func=lambda self, context: self.layout.label(
+					text='There are one or more invalid mappings (marked red).'
+				)
+			)
+			return
+
+		leave_mapping_mode(context.object.retargeting_context)
+		return {'FINISHED'}
+
+
+
+class MappingsListActionOperator(bpy.types.Operator):
+	bl_idname = 'mappings.list_action'
+	bl_label = ''
+	action: bpy.props.StringProperty()
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+
+		if self.action == 'ADD':
+			ctx.mappings.add()
+			ctx.active_mapping = len(ctx.mappings) - 1
+		elif self.action == 'REMOVE':
+			if len(ctx.mappings) > 0:
+				ctx.mappings.remove(ctx.active_mapping)
+				ctx.active_mapping =  min(ctx.active_mapping, len(ctx.mappings) - 1)
+
+		return {'FINISHED'}
+
+
+
+class MappingsGuessOperator(bpy.types.Operator):
+	bl_idname = 'mappings.guess'
+	bl_label = 'Guess Bone Mappings'
+	bl_description = 'Attempt to map source to target bones automatically based on name and topology'
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.ui_guessing_mappings = True
+		ctx.source.select_set(False)
+		return {'FINISHED'}
+
+
+
+class MappingsGuessCancelOperator(bpy.types.Operator):
+	bl_idname = 'mappings.guess_cancel'
+	bl_label = 'Cancel Bone Mappings Guess'
+	bl_description = 'Do not continue with attempting to guess bone mappings'
+
+	def execute(self, context):
+		context.object.retargeting_context.ui_guessing_mappings = False
+		return {'FINISHED'}
+	
+
+
+class MappingsGuessApplyOperator(bpy.types.Operator):
+	bl_idname = 'mappings.guess_apply'
+	bl_label = 'Apply Bone Mappings Guess'
+	bl_description = 'Attempting to guess bone mappings based on the bone selection made'
+
+	def execute(self, context):
+		guess_mappings(context.object.retargeting_context)
+		return {'FINISHED'}
+
+
+class MappingsClearOperator(bpy.types.Operator):
+	bl_idname = 'mappings.clear'
+	bl_label = 'Reset Bone Mappings'
+	bl_description = 'Clears all existing source-target bone mappings'
+	bl_options = {'REGISTER', 'INTERNAL'}
+
+	def invoke(self, context, event):
+		return context.window_manager.invoke_confirm(self, event)
+
+	def execute(self, context):
+		ctx = context.object.retargeting_context
+		ctx.reset()
+		ctx.clear_drivers()
+		return {'FINISHED'}
+	
+
+
+class MappingsUseInvalidSourceAnywayOperator(bpy.types.Operator):
+	bl_idname = 'mappings.use_invalid_source_anyway'
+	bl_label = 'Use anyway'
+	bl_description = 'Use the incompatible source armature anyways. Target bones that have no corresponding source bone will be ignored'
+
+	def execute(self, context):
+		context.object.retargeting_context.handle_source_update(ignore_incompat=True)
+		return {'FINISHED'}
+
+
+classes = (
+	RT_UL_mappings,
+	MappingsApplyOperator,
+	MappingsEditOperator,
+	MappingsListActionOperator,
+	MappingsGuessOperator,
+	MappingsGuessCancelOperator,
+	MappingsGuessApplyOperator,
+	MappingsClearOperator,
+	MappingsUseInvalidSourceAnywayOperator
+)

--- a/savefile.py
+++ b/savefile.py
@@ -1,0 +1,133 @@
+import bpy
+import json
+from bpy_extras.io_utils import ExportHelper, ImportHelper
+from .util import matrix_to_list
+
+
+def draw_panel(ctx, layout):
+	layout.enabled = not ctx.ui_editing_mappings and not ctx.ui_editing_alignment
+
+	row = layout.row()
+	row.operator(SavefileLoadOperator.bl_idname, icon='FILEBROWSER')
+	row.operator(SavefileSaveOperator.bl_idname, icon='FILE_TICK')
+
+
+
+class SavefileLoadOperator(bpy.types.Operator, ImportHelper):
+	bl_idname = 'savefile.load'
+	bl_label = 'Load Config'
+	bl_description = 'Load bone mappings, alignments and other settings from a file. Can be applied to any armature with identical bone names'
+
+	filter_glob: bpy.props.StringProperty(
+		default='*.blend*',
+		options={'HIDDEN'},
+		maxlen=255
+	)
+
+	def execute(self, context):
+		with open(self.filepath, 'r') as f:
+			load_serialized_state(context.object.retargeting_context, json.load(f))
+		return {'FINISHED'}
+
+
+
+class SavefileSaveOperator(bpy.types.Operator, ExportHelper):
+	bl_idname = 'savefile.save'
+	bl_label = 'Save Config'
+	filename_ext = '.blend-retarget'
+	bl_description = 'Save bone mappings, alignments and other settings from a file. Can be applied to any armature with identical bone names'
+
+	filter_glob: bpy.props.StringProperty(
+		default='*.blend-retarget',
+		options={'HIDDEN'},
+		maxlen=255
+	)
+
+	def execute(self, context):
+		with open(self.filepath, 'w') as f:
+			f.write(
+				json.dumps(
+					serialize_state(context.object.retargeting_context),
+					indent=4
+				)
+			)
+
+		return {'FINISHED'}
+
+
+
+def serialize_state(ctx):
+	return {
+		'armatures': {
+			'source': serialize_armature(ctx.source),
+			'target': serialize_armature(ctx.target)
+		},
+		'mappings': [
+			{
+				'source': m.source,
+				'target': m.target,
+				'rest': list(m.rest),
+				'offset': list(m.offset)
+			}
+			for m in ctx.mappings
+		], 
+		'ik_limbs': [
+			{
+				'name': l.name,
+				'enabled': l.enabled,
+				'target_bone': l.target_bone,
+				'origin_bone': l.origin_bone,
+				'control_transform': list(l.control_transform)
+			} 
+			for l in ctx.ik_limbs
+		], 
+		'setting_correct_feet': ctx.setting_correct_feet, 
+		'setting_correct_hands': ctx.setting_correct_hands
+	}
+
+
+def serialize_armature(armature):
+	return {
+		'matrix_world': matrix_to_list(armature.matrix_world),
+		'bones': {
+			bone.name: {
+				'parent': bone.parent.name if bone.parent else None,
+				'matrix': matrix_to_list(bone.matrix),
+				'matrix_local': matrix_to_list(bone.matrix_local)
+			}
+			for bone in armature.data.bones
+		}
+	}
+
+
+def load_serialized_state(ctx, data):
+	ctx.is_importing = True
+	ctx.reset()
+
+	for m in data['mappings']:
+		mapping = ctx.mappings.add()
+		mapping.source = m['source']
+		mapping.target = m['target']
+		mapping.rest = m['rest']
+		mapping.offset = m['offset']
+
+	for l in data['ik_limbs']:
+		limb = ctx.ik_limbs.add()
+		limb.name = l['name']
+		limb.enabled = l['enabled']
+		limb.target_bone = l['target_bone']
+		limb.origin_bone = l['origin_bone']
+		limb.control_transform = l['control_transform']
+
+	ctx.setting_correct_feet = data['setting_correct_feet']
+	ctx.setting_correct_hands = data['setting_correct_hands']
+	ctx.is_importing = False
+
+	ctx.update_drivers()
+
+
+
+classes = (
+	SavefileLoadOperator,
+	SavefileSaveOperator
+)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,44 @@
+import bpy
+from mathutils import Matrix
+
+
+def rot_mat(mat):
+	return mat.to_quaternion().to_matrix().to_4x4()
+
+
+def loc_mat(mat):
+	return Matrix.Translation(mat.to_translation()).to_4x4()
+
+
+def extract_rot_axis_from_mat(mat, axis):
+	return getattr(mat.to_quaternion().to_euler(), axis)
+
+
+def extract_loc_axis_from_mat(mat, axis):
+	return getattr(mat.to_translation(), axis)
+
+
+def list_to_matrix(values):
+	if len(values) == 4 * 4:
+		size = 4
+	elif len(values) == 3 * 3:
+		size = 3
+	else:
+		raise Exception('invalid matrix size when deserializing')
+	
+	rows = []
+	
+	for i in range(0, len(values), size):
+		rows.append(values[i:i+size])
+
+	return Matrix(rows)
+
+
+def matrix_to_list(matrix):
+	values = []
+
+	for row in matrix:
+		for value in row:
+			values.append(value)
+
+	return values


### PR DESCRIPTION
Replaces deprecated logger.warn() call with logger.warning() to resolve Python 3.13+ deprecation warnings.